### PR TITLE
fix(breakTime): enforce break sequence rules

### DIFF
--- a/main.go
+++ b/main.go
@@ -51,6 +51,8 @@ func (d *DefaultSleeper) showProgress(totalMinutes int, label string) {
 }
 
 func main() {
+
+	pomodoroPrinter := pomodoro.PomodoroOperations{Calls: make([]string, 0)}
 	workDuration := flag.Int("work", 0, "Work duration in minutes")
 	shortBreakDuration := flag.Int("sbreak", 0, "Short break duration in minutes")
 	longBreakDuration := flag.Int("lbreak", 0, "Long break duration in minutes")
@@ -59,5 +61,5 @@ func main() {
 
 	sleeper := DefaultSleeper{progressWriter: os.Stdout}
 
-	pomodoro.Pomodoro(&sleeper, *workDuration, *shortBreakDuration, *longBreakDuration)
+	pomodoro.Pomodoro(&pomodoroPrinter, &sleeper, *workDuration, *shortBreakDuration, *longBreakDuration)
 }

--- a/pomodoro/pomodoro.go
+++ b/pomodoro/pomodoro.go
@@ -1,8 +1,12 @@
 package pomodoro
 
 const DEFAULT_WORK_TIMER int = 25
-const DEFAULT_SHORT_BREAK int  = 5
+const DEFAULT_SHORT_BREAK int = 5
 const DEFAULT_LONG_BREAK int = 15
+const CICLES_PER_LAP int = 4
+const work string = "work"
+const shortBreak string = "shortBreak"
+const longBreak string = "longBreak"
 
 type Sleeper interface {
 	Work(minutes int)
@@ -10,9 +14,23 @@ type Sleeper interface {
 	LongBreak(minutes int)
 }
 
+type PomodoroOperations struct {
+	Calls []string
+}
+
+func (p *PomodoroOperations) Work() {
+	p.Calls = append(p.Calls, work)
+}
+func (p *PomodoroOperations) shortBreak() {
+	p.Calls = append(p.Calls, shortBreak)
+}
+func (p *PomodoroOperations) longBreak() {
+	p.Calls = append(p.Calls, longBreak)
+}
+
 // args should be supplied like this:
 // gomodoro start --work 25m --break 5m
-func Pomodoro(sleeper Sleeper, work, shortBreak, longBreak int) {
+func Pomodoro(operation *PomodoroOperations, sleeper Sleeper, work, shortBreak, longBreak int) {
 	if work == 0 {
 		work = DEFAULT_WORK_TIMER
 	}
@@ -25,10 +43,16 @@ func Pomodoro(sleeper Sleeper, work, shortBreak, longBreak int) {
 		longBreak = DEFAULT_LONG_BREAK
 	}
 
-	for range 4 {
+	for actualCicle := 1; actualCicle <= CICLES_PER_LAP; actualCicle++ {
 		sleeper.Work(work)
-		sleeper.ShortBreak(shortBreak)
+		operation.Work()
+		if actualCicle == CICLES_PER_LAP {
+			sleeper.LongBreak(longBreak)
+			operation.longBreak()
+		} else {
+			sleeper.ShortBreak(shortBreak)
+			operation.shortBreak()
+		}
 	}
 
-	sleeper.LongBreak(longBreak)
 }

--- a/pomodoro/pomodoro_test.go
+++ b/pomodoro/pomodoro_test.go
@@ -46,7 +46,8 @@ func TestPomodoro(t *testing.T) {
 	t.Run("it should use default params when no args are supplied", func(t *testing.T) {
 		sleeper := SpySleeper{}
 
-		Pomodoro(&sleeper, 0, 0, 0)
+		pomodoroPrinter := PomodoroOperations{Calls: make([]string, 0)}
+		Pomodoro(&pomodoroPrinter, &sleeper, 0, 0, 0)
 
 		want := SpySleeper{CallCount: sleeper.CallCount, WorkTime: DEFAULT_WORK_TIMER, ShortBreakTime: DEFAULT_SHORT_BREAK, LongBreakTime: DEFAULT_LONG_BREAK}
 		got := sleeper
@@ -61,8 +62,9 @@ func TestPomodoro(t *testing.T) {
 		workTimer := 10
 		shortBreakTimer := 15
 		longBreakTimer := 5
+		pomodoroPrinter := PomodoroOperations{Calls: make([]string, 0)}
 
-		Pomodoro(&sleeper, workTimer, shortBreakTimer, longBreakTimer)
+		Pomodoro(&pomodoroPrinter,&sleeper, workTimer, shortBreakTimer, longBreakTimer)
 
 		want := SpySleeper{CallCount: sleeper.CallCount, WorkTime: workTimer, ShortBreakTime: shortBreakTimer, LongBreakTime: longBreakTimer}
 		got := sleeper
@@ -75,15 +77,40 @@ func TestPomodoro(t *testing.T) {
 	// Already done by flag module
 	// t.Run("it should throw a error when invalid args are supplid", func(t *testing.T) {})
 
-	t.Run("it should run 4x work/short break before taking 1 long break", func(t *testing.T) {
+	t.Run("it should run 4x work and 3x short break before taking 1 long break", func(t *testing.T) {
 		sleeper := SpySleeper{}
-		Pomodoro(&sleeper, 0, 0, 0)
 
-		want := CallCount{Work: 4, ShortBreak: 4, LongBreak: 1}
+		pomodoroPrinter := PomodoroOperations{Calls: make([]string, 0)}
+		Pomodoro(&pomodoroPrinter, &sleeper, 0, 0, 0)
+
+		want := CallCount{Work: 4, ShortBreak: 3, LongBreak: 1}
 		got := sleeper.CallCount
 
 		if !reflect.DeepEqual(want, got) {
 			t.Errorf("expect %v, got %v", want, got)
 		}
+	})
+
+	t.Run("Testing the order of the pomodoro call", func(t *testing.T) {
+		sleeper := SpySleeper{}
+
+		pomodoroPrinter := PomodoroOperations{Calls: make([]string, 0)}
+		Pomodoro(&pomodoroPrinter, &sleeper, 4, 3, 1)
+
+		want := []string{
+			work,
+			shortBreak,
+			work,
+			shortBreak,
+			work,
+			shortBreak,
+			work,
+			longBreak,
+		}
+
+		if !reflect.DeepEqual(want, pomodoroPrinter.Calls) {
+			t.Errorf("wanted calls %v got %v", want, pomodoroPrinter.Calls)
+		}
+
 	})
 }


### PR DESCRIPTION
- Modify breakTime logic to prevent invalid transitions
- Ensure shortBreak cannot be immediately followed by longBreak  learning mocking