### PR TITLE
fix(breakTime): enforce break sequence rules

### DIFF
--- a/main.go
+++ b/main.go
@@ -51,6 +51,8 @@ func (d *DefaultSleeper) showProgress(totalMinutes int, label string) {
 }
 
 func main() {
+
+	pomodoroPrinter := pomodoro.PomodoroOperations{Calls: make([]string, 0)}
 	workDuration := flag.Int("work", 0, "Work duration in minutes")
 	shortBreakDuration := flag.Int("sbreak", 0, "Short break duration in minutes")
 	longBreakDuration := flag.Int("lbreak", 0, "Long break duration in minutes")
@@ -59,5 +61,5 @@ func main() {
 
 	sleeper := DefaultSleeper{progressWriter: os.Stdout}
 
-	pomodoro.Pomodoro(&sleeper, *workDuration, *shortBreakDuration, *longBreakDuration)
+	pomodoro.Pomodoro(&pomodoroPrinter, &sleeper, *workDuration, *shortBreakDuration, *longBreakDuration)
 }

--- a/pomodoro/pomodoro.go
+++ b/pomodoro/pomodoro.go
@@ -1,8 +1,12 @@
 package pomodoro
 
 const DEFAULT_WORK_TIMER int = 25
-const DEFAULT_SHORT_BREAK int  = 5
+const DEFAULT_SHORT_BREAK int = 5
 const DEFAULT_LONG_BREAK int = 15
+const CICLES_PER_LAP int = 4
+const work string = "work"
+const shortBreak string = "shortBreak"
+const longBreak string = "longBreak"
 
 type Sleeper interface {
 	Work(minutes int)
@@ -25,10 +29,13 @@ func Pomodoro(sleeper Sleeper, work, shortBreak, longBreak int) {
 		longBreak = DEFAULT_LONG_BREAK
 	}
 
-	for range 4 {
+	for actualCicle := 1; actualCicle <= CICLES_PER_LAP; actualCicle++ {
 		sleeper.Work(work)
-		sleeper.ShortBreak(shortBreak)
+		if actualCicle == CICLES_PER_LAP {
+			sleeper.LongBreak(longBreak)
+		} else {
+			sleeper.ShortBreak(shortBreak)
+		}
 	}
 
-	sleeper.LongBreak(longBreak)
 }


### PR DESCRIPTION
- Modify breakTime logic to prevent invalid transitions
- Ensure shortBreak cannot be immediately followed by longBreak  learning mocking